### PR TITLE
Resolve of self-referencing use case for Solidity.

### DIFF
--- a/docs/S00-intro/L2-why-learn/index.md
+++ b/docs/S00-intro/L2-why-learn/index.md
@@ -8,7 +8,7 @@
   
   To achieve this paradigm shift, blockchain relies fundamentally on two fields of computer science: [**Distributed Computing**](https://en.wikipedia.org/wiki/Distributed_computing) and [**Cryptography**](https://en.wikipedia.org/wiki/Cryptography). We will cover these topics in the first section of the course.
   
-  This paradigm shift requires changes from the developer _and_ the user. In the next section of the course, we'll go over what the protocol-layer changes of blockchain mean for you as a developer. We'll then introduce you to Solidity, the language for developing Solidity, as well as the tools you'll need to build. We'll also discuss the changes for the user, including how requiring private key signatures dramatically changes user workflow.
+  This paradigm shift requires changes from the developer _and_ the user. In the next section of the course, we'll go over what the protocol-layer changes of blockchain mean for you as a developer. We'll then introduce you to Solidity, the language for developing smart contracts, as well as the tools you'll need to build. We'll also discuss the changes for the user, including how requiring private key signatures dramatically changes user workflow.
   
   While there's enormous promise with blockchain development, it requires an awareness of the paradigm shift and an expertise in the fundamental concepts underpinning it. Otherwise, we are inevitably going to recreate the same, centralized monolith we have today.
   


### PR DESCRIPTION
Resolve of self-referencing use case: "Solidity [...] for developing Solidity." 
Changed to: "Solidity [...] for developing smart contracts." 