### PR TITLE
Update sending transactions page to warn about 3rd party cookies issue on notebook.

### DIFF
--- a/docs/S02-ethereum/M3-state/L4-txn-tutorial/index.html
+++ b/docs/S02-ethereum/M3-state/L4-txn-tutorial/index.html
@@ -17,6 +17,10 @@
 
   <p>We're created an <a href="https://observablehq.com/@consensys-academy/externally-owned-accounts-and-ethereum-transactions" target="_blank" rel="noopener noreferrer">interactive Observable notebook</a> to learn more about Externally Owned Accounts signing and sending transactions into the network. <a href="https://observablehq.com/@consensys-academy/externally-owned-accounts-and-ethereum-transactions" target="_blank" rel="noopener noreferrer">You can find the tutorial here.</a></p>
   
+  <p>If the notebook doesn't operate properly or you get the error 
+    <quote>Web3js = SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.</quote> you will need to enable third party cookies.<br/>
+    This varies from browser to browser.
+  </p>
   <!-- Content here: -->
 
     <p></p>


### PR DESCRIPTION
Put in notice here on the observable notebook about having to enable third party cookies to let the notebook operate correctly on chrome or other modern browsers with ad-block software and or 3rd party cookies disabled by default.

