### PR TITLE
Fixed Chapter 2 "Ethereum Background and History" - closing </a> tag for external reference

### DIFF
--- a/docs/S02-ethereum/M1-background/index.html
+++ b/docs/S02-ethereum/M1-background/index.html
@@ -50,7 +50,7 @@
   <ul>
     <li><a href="https://consensys.net/blog/blockchain-explained/a-short-history-of-ethereum/" target="_blank" rel="noopener noreferrer">Article: A Short History of Ethereum (ConsenSys)</a></li>
     <li><a href="https://consensys.net/blog/blockchain-explained/what-is-ethereum-2" target="_blank" rel="noopener noreferrer">Article: What is Ethereum 2.0? (ConsenSys)</a></li>
-    <li><a href="https://www.reddit.com/r/ethereum/comments/5v76ne/what_is_the_difference_between_erc_and_eip/" target="_blank" rel="noopener noreferrer"></a>Reddit: What's the Difference Between ERC and EIP?</li>
+    <li><a href="https://www.reddit.com/r/ethereum/comments/5v76ne/what_is_the_difference_between_erc_and_eip/" target="_blank" rel="noopener noreferrer">Reddit: What's the Difference Between ERC and EIP?</a></li>
     <li><a href="https://eips.ethereum.org/" target="_blank" rel="noopener noreferrer">Wiki: Ethereum Improvement Proposals</a> Learn here about the Ethereum Improvement Proposal (EIP), the way in which standards to the protocols are created, developed, changed and (potentially) implemented.</li>
     <li><a href="https://ethereum.org/en/community/" target="_blank" rel="noopener noreferrer">Wiki: Ethereum Community</a> Great resource where you can learn how to get involved in the Ethereum community.</li>
     <li><a href="https://hudsonjameson.com/2020-06-22-what-is-an-ethereum-core-developer/" target="_blank" rel="noopener noreferrer">Article: What is an Ethereum Core Developer? (Hudson Jameson)</a> Great article detailing the previously-undefined term of a "Core Developer." Jameson comes up with this definition, "Ethereum core developers are people who currently provide significant contributions to Ethereum low-level protocol development"</li>


### PR DESCRIPTION
The closing </a> tag for "Reddit: What's the Difference Between ERC and EIP?" was placed before the link text itself so nothing can be clicked. Fixed it by moving it to after the text.