### PR TITLE
fix a link

### DIFF
--- a/docs/S02-ethereum/M5-installing-geth/index.md
+++ b/docs/S02-ethereum/M5-installing-geth/index.md
@@ -20,7 +20,7 @@ Geth has several interfaces through which you can communicate with your Ethereum
 *   JSON-RPC server: you can start geth with a json-rpc server that exposes the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC){target=_blank}
 *   [Command line options](https://github.com/ethereum/go-ethereum/wiki/Command-Line-Options){target=_blank} documents command line parameters as well as subcommands.
 
-[See this page](https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum){target=_blank} for instructions on how to install geth for your platform.
+[See this page](https://geth.ethereum.org/docs/install-and-build/installing-geth){target=_blank} for instructions on how to install geth for your platform.
 
 Install geth and start interacting with our node.
 


### PR DESCRIPTION
Just fixing the link "See this page for instructions on how to install geth for your platform."

To go to https://geth.ethereum.org/docs/install-and-build/installing-geth