### PR TITLE
Adding ahref Truffle documentation

### DIFF
--- a/docs/S03-smart-contracts/M2-intro-to-truffle/L2-intro-tutorial/index.html
+++ b/docs/S03-smart-contracts/M2-intro-to-truffle/L2-intro-tutorial/index.html
@@ -198,7 +198,7 @@ Summary
 
     <p>One of the key output values from the above is the contract address (<code>0x524B2860a2489E385C5e12537f58d5a09A9d33ab</code> in the above example). As the name might suggest, this is the address of the deployed instance of contract and the means with how you’d reference it when sending future transactions.</p>
     
-    <p>Migrations is definitely more of a deeper topic that we’ll be covering more later. In the interim,  more details on migrations can be found in Truffle’s documentation here.</p>
+    <p>Migrations is definitely more of a deeper topic that we’ll be covering more later. In the interim,  more details on migrations can be found in Truffle’s documentation <a href="https://www.trufflesuite.com/docs/truffle/getting-started/running-migrations" target="_blank" rel="noopener noreferrer">here.</a></p>
 
   <h2>Interacting with SimpleStorage</h2>
 


### PR DESCRIPTION
There is a reference of "Truffle’s documentation here " in section Introduction to Truffle Suite — Part 2.