### PR TITLE
Fixed grammatical error in the `Solidity Background and Context` course

### DIFF
--- a/docs/S03-smart-contracts/M2-solidity/L1-background-context/index.html
+++ b/docs/S03-smart-contracts/M2-solidity/L1-background-context/index.html
@@ -84,7 +84,7 @@
       <li><a href="https://en.wikipedia.org/wiki/Solidity" target="_blank" rel="noopener noreferrer">Wikipedia: Solidity</a></li>
       <li><a href="https://docs.soliditylang.org/en/latest/" target="_blank" rel="noopener noreferrer">Docs: Official Solidity Documentation</a></li>
     </ul>
-    <p>If you'd like some other places to learn Solidity, you can also check out these great resources. To be clear, we'll definitely be teaching you Solidity along with how to developer dapps. We also want to provide any external help we can as well!</p>
+    <p>If you'd like some other places to learn Solidity, you can also check out these great resources. To be clear, we'll definitely be teaching you Solidity along with how to develop dapps. We also want to provide any external help we can as well!</p>
     <ul>
       <li><a href="https://cryptozombies.io/" target="_blank" rel="noopener noreferrer">Course: CryptoZombies</a> One of the most well-known introductions to Solidity</li>
       <li><a href="https://ethernaut.openzeppelin.com/" target="_blank" rel="noopener noreferrer">Course: Ethernaut (OpenZeppelin)</a> An excellent in-browser "game" teaching Solidity from a security perspective.</li>


### PR DESCRIPTION
A fixed grammatical error in the `Solidity Background and Context` course