### PR TITLE
Add youtube link video

### DIFF
--- a/docs/S07-additional-topics/L3-the-graph/index.md
+++ b/docs/S07-additional-topics/L3-the-graph/index.md
@@ -57,7 +57,7 @@ For a more general guide on how to get started with web3, check out [this guide]
 
 ## Querying from a Frontend Application
 
-Follow [the guide in Gitpod](https://github.com/graphprotocol/full-stack-graph-app) and video below:
+Follow [the guide in Gitpod](https://github.com/graphprotocol/full-stack-graph-app) and [video](https://www.youtube.com/watch?v=PjyKPMpahuc) below:
 
 <!-- blank line -->
 <figure class="video_container">


### PR DESCRIPTION
Although the youtube link for "Querying from a Frontend Application" section is right, the embedded video isn't showing. So I'm adding the direct link video in the word "video" there.