### PR TITLE
ADDED missing instructions

### DIFF
--- a/docs/S07-additional-topics/L2-filecoin/index.md
+++ b/docs/S07-additional-topics/L2-filecoin/index.md
@@ -92,6 +92,7 @@ asset - <a href="https://ipfs.io/ipfs/QmS4t7rFPxaaNriXvCmALr5GYRAtya5urrDaZgkfHu
 Assuming the local Ethereum Ganache node is running, you'll be able to open a console and mint a new NFT with the following steps. As the base URL is set to that of an IPFS gateway, we'll just need to pass in the CID to the asset metadata.
  
 
+    truffle migrate
     truffle console
     truffle(development)> const gallery = await MyGallery.deployed()
     truffle(development)> gallery.mint(accounts[0], "QmS4t7rFPxaaNriXvCmALr5GYRAtya5urrDaZgkfHutdCG")


### PR DESCRIPTION
Added a missing instruction to perform the truffle migrate command prior to running truffle console. Migration is required before being able to access the contracts from the truffle console