### PR TITLE
FIX missing url for RFQ's

### DIFF
--- a/docs/S05a-defi/M5c-rfqs/L1/index.md
+++ b/docs/S05a-defi/M5c-rfqs/L1/index.md
@@ -18,11 +18,12 @@ RFQ facilities direct trade between parties which is:
 - Efficient - Eliminates slippage, so you get what you paid for.
 - Scalable - negotiations happen off-chain (not on Ethereum) and scales better than relying solely on Ethereum’s throughput.
 
-![airswap overview](../../../img/S05/airswap-rfq-overview.png)
+![
+overview](../../../img/S05/airswap-rfq-overview.png)
 
 ## Summary
 
-Request for Quote handles trades with off-chain negotiations and on-chain settlement (https://about.airswap.io/technology/request-for-quote){target=\_blank}. Market makers are called Makers who run servers to fulfil orders. Counterparties to makers are called Takers, who wish to trade tokens.
+Request for Quote handles trades with off-chain negotiations and on-chain settlement ([trades](https://about.airswap.io/technology/request-for-quote){target=\_blank}). Market makers are called Makers who run servers to fulfil orders. Counterparties to makers are called Takers, who wish to trade tokens.
 
 RFQ can be seen as a peer-to-peer system. The protocol’s smart contracts focus on on-chain settlement of trades via "atomic" swaps using smart contracts. Price discovery and negotiation are made off-chain via RPC (remote procedure calls){target=\_blank}, which is scalable and resistant to AMM issues related to front running and miner extractable value.
 


### PR DESCRIPTION
The {target=\_blank} command is used inferring that there should be a url for linking. Based on the context of the sentence, it appears the RFQ section of the airswap docs should be linked