### PR TITLE
FIX missing RPC informative url

### DIFF
--- a/docs/S05a-defi/M5c-rfqs/L1/index.md
+++ b/docs/S05a-defi/M5c-rfqs/L1/index.md
@@ -24,7 +24,7 @@ RFQ facilities direct trade between parties which is:
 
 Request for Quote handles trades with off-chain negotiations and on-chain settlement (trades){target=\_blank}. Market makers are called Makers who run servers to fulfil orders. Counterparties to makers are called Takers, who wish to trade tokens.
 
-RFQ can be seen as a peer-to-peer system. The protocol’s smart contracts focus on on-chain settlement of trades via "atomic" swaps using smart contracts. Price discovery and negotiation are made off-chain via RPC (remote procedure calls){target=\_blank}, which is scalable and resistant to AMM issues related to front running and miner extractable value.
+RFQ can be seen as a peer-to-peer system. The protocol’s smart contracts focus on on-chain settlement of trades via "atomic" swaps using smart contracts. Price discovery and negotiation are made off-chain via RPC (https://en.wikipedia.org/wiki/Remote_procedure_call){target=\_blank}, which is scalable and resistant to AMM issues related to front running and miner extractable value.
 
 This model exists because of Ethereum’s constraints and the issues around large orders on AMMs mentioned previously.
 

--- a/docs/S05a-defi/M5c-rfqs/L1/index.md
+++ b/docs/S05a-defi/M5c-rfqs/L1/index.md
@@ -24,7 +24,7 @@ RFQ facilities direct trade between parties which is:
 
 Request for Quote handles trades with off-chain negotiations and on-chain settlement (trades){target=\_blank}. Market makers are called Makers who run servers to fulfil orders. Counterparties to makers are called Takers, who wish to trade tokens.
 
-RFQ can be seen as a peer-to-peer system. The protocol’s smart contracts focus on on-chain settlement of trades via "atomic" swaps using smart contracts. Price discovery and negotiation are made off-chain via RPC (https://en.wikipedia.org/wiki/Remote_procedure_call){target=\_blank}, which is scalable and resistant to AMM issues related to front running and miner extractable value.
+RFQ can be seen as a peer-to-peer system. The protocol’s smart contracts focus on on-chain settlement of trades via "atomic" swaps using smart contracts. Price discovery and negotiation are made off-chain via RPC ([remote procedure call](https://en.wikipedia.org/wiki/Remote_procedure_call){target=\_blank}), which is scalable and resistant to AMM issues related to front running and miner extractable value.
 
 This model exists because of Ethereum’s constraints and the issues around large orders on AMMs mentioned previously.
 


### PR DESCRIPTION
the {target=\_blank} command is used in reference to remote procedure call infering that a link to a descriptive resource of RPC should be included. the current state of the document does not include a link, therefore I added a wikipedia link to RPC for reference