### PR TITLE
FIX command order for example

### DIFF
--- a/docs/S07-additional-topics/L2-filecoin/index.md
+++ b/docs/S07-additional-topics/L2-filecoin/index.md
@@ -46,8 +46,8 @@ An alternative to running Filecoin Ganache via the CLI is to use Filecoin Ganche
         
     git clone https://github.com/trufflesuite/filecoin-network-inspector
     cd filecoin-network-inspector
-    npm install
     git checkout ganache-changes
+    npm install
     npm run start
 
 ## Running Ethereum Ganache


### PR DESCRIPTION
When running the Filecoin network explorer, the command for checking out the ganache-changes should be performed before running npm install. Reordered the commands so that others don't run into issues when trying to checkout after running npm install