### PR TITLE
FIX missing link text

### DIFF
--- a/docs/S10-eth2/M3-future-considerations/index.md
+++ b/docs/S10-eth2/M3-future-considerations/index.md
@@ -22,4 +22,4 @@ The Rayonism testnet did run for a short period of time. You can checkout the Me
 - <a href="https://ethereum-magicians.org/t/a-rollup-centric-ethereum-roadmap/4698" target="_blank" rel="noopener noreferrer">Forum: A Rollup-centric Ethereum Roadmap</a>
 - <a href="https://github.com/ethereum/pm/blob/master/Merge/mainnet-readiness.md" target="_blank" rel="noopener noreferrer">GitHub: Mainnet Readiness Checklist</a>
 - <a href="https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/beacon-chain.md" target="_blank" rel="noopener noreferrer">GitHub: Eth1 and Eth2 Merge spec</a>
-- <a href="https://rayonism.io/" target="_blank" rel="noopener noreferrer"></a>
+- <a href="https://rayonism.io/" target="_blank" rel="noopener noreferrer">Rayonism: a research and engineering testnet that combines Eth1-Eth2 Merge and Sharding</a>


### PR DESCRIPTION
The last bullet point of the Additional Materials had an <a> tag with missing text information so an appropriate text was written to accompany the href attribute and context of this chapter