### PR TITLE
FIXED infura instructions for clarity

### DIFF
--- a/docs/S08-scalability/M4-examples/L1-optimism/index.md
+++ b/docs/S08-scalability/M4-examples/L1-optimism/index.md
@@ -41,7 +41,7 @@ After this example, you will be able to compile, migrate, and test Optimistic So
 <a href="https://docs.docker.com/compose/install/" target="_blank" rel="noopener noreferrer">docker-compose</a>, version 1.27.3 or later
 - Recommended Docker memory allocation of >=8 GB.
 
-You'll also need to setup an Optimism project from your Infura account. You don't have to update your account, right now access is being offered at the "core" level for free up to 100,000 daily requests. When setting up your project, be sure to select the "Ethereum" network. Then, under settings, select the "Optimism Kovan" testnet, as shown below:
+You'll also need to setup an Optimism project from your Infura account. You don't have to update your account, right now access is being offered at the "core" level for free up to 100,000 daily requests. You must enable the Optimistic Ethereum ADD-ON under the billing section under Manage Add-Ons in your Infura account Settings for the API requests to work properly. When setting up your project, be sure to select the "Ethereum" network. Then, under settings, select the "Optimism Kovan" testnet, as shown below:
 
 ![Setting up an Infura project for Optimism testnet](../../../img/S08/optimism-tutorial-1.png)
 


### PR DESCRIPTION
In order for the infura api requests to work with Optimistic Ethereum, the appropriate network add on must be selected in the user account settings, so this instruction has been added for clarity