### PR TITLE
Update steps to create multiple accounts

### DIFF
--- a/docs/S02-ethereum/M5-installing-geth/index.md
+++ b/docs/S02-ethereum/M5-installing-geth/index.md
@@ -207,7 +207,11 @@ An ethereum transaction includes the following data:
 
 <code>nonce:</code> Number - (optional) Integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce.
 
-To send some ether to another account, you just need to specify the send, the recipient and the value.
+To send some ether to another account, first create another account.
+
+    > personal.newAccount()
+
+Next initiate the transaction by specifying the to, the from and the value.
 
     > eth.sendTransaction({to: eth.accounts[1], from: eth.accounts[0], value: 100})
 


### PR DESCRIPTION
Currently it asks you to send a transaction to another account when that other account does not yet exist.

I added a step to create another account prior to initiating a transaction.