### PR TITLE
[FIX] .value(amount) has been depreciated

### DIFF
--- a/docs/S03-smart-contracts/M6-security/L2-solidity-pitfalls-and-attacks/index.html
+++ b/docs/S03-smart-contracts/M6-security/L2-solidity-pitfalls-and-attacks/index.html
@@ -132,7 +132,7 @@ fallback() external {
         <pre class="wrong">
 function withdraw(uint amount) public {       // Possibly dangerous
   require(balances[msg.sender] >= amount);
-  msg.sender.call.value(amount)("");
+  msg.sender.call{value:amount}("");
   balances[msg.sender] -= amount;
 }
         </pre>
@@ -140,7 +140,7 @@ function withdraw(uint amount) public {       // Possibly dangerous
 function withdraw(uint amount) public {    // Better!
   require(balances[msg.sender] >= amount);
   balances[msg.sender] -= amount;
-  msg.sender.call.value(amount)("");
+  msg.sender.call{value:amount}("");
 }
         </pre>
       </p>
@@ -162,7 +162,7 @@ contract Vulnerable {         // Possibly dangerous
 contract Fixed {            // Better!
   function withdraw(uint256 amount) external {
       // This forwards all available gas. Be sure to check the return value!
-      (bool success, ) = msg.sender.call.value(amount)("");
+      (bool success, ) = msg.sender.call{value:amount}("");
       require(success, "Transfer failed.");
   }
 }


### PR DESCRIPTION
`.value()` was depreciated in 0.7.0
![image](https://user-images.githubusercontent.com/86927059/144107342-12c0a7f0-ca67-4d74-ad1d-e442b1479b0f.png)

 Replaced with `{value:amount}` per Solidity docs
![image](https://user-images.githubusercontent.com/86927059/144107224-c14451f4-ce70-486f-b7aa-619b8ae20646.png)
https://ethereum.stackexchange.com/questions/82412/using-value-is-deprecated-use-value-instead