### PR TITLE
Update link

### DIFF
--- a/docs/S04-developer-tooling/M2-web3-libraries/L2-web3-connect-to-contract/index.md
+++ b/docs/S04-developer-tooling/M2-web3-libraries/L2-web3-connect-to-contract/index.md
@@ -115,7 +115,7 @@ You can easily subscribe to events with simpleStorage. Notice we have a "storage
 
 To listen for that event, run `simpleStorage.events.storageUpdate(function(error, event){console.log(event)})`
 
-[Here is a link to the relevant web3.js documentation for subscribing to events.](https://web3js.readthedocs.io/en/latest/web3-eth-contract.html#contract-events){target=_blank}
+[Here is a link to the relevant web3.js documentation for subscribing to events.](https://web3js.readthedocs.io/en/v1.2.11/web3-eth-contract.html#events){target=_blank}
 
 To trigger this event, you will have to call the "set()" function on the contract again. Once the update transaction is mined, the event will fire. This is what it looks like in the browser console.
 


### PR DESCRIPTION
I think this link https://web3js.readthedocs.io/en/latest/web3-eth-contract.html#contract-events leads to a non-existing page. 
![image](https://user-images.githubusercontent.com/19472085/148495924-691bdc23-3f3b-4072-abf2-07887dbca409.png)
Found another link https://web3js.readthedocs.io/en/v1.2.11/web3-eth-contract.html#events