### PR TITLE
[S10-eth2/M1-background] Adds Decrypt Ropsten Merge article

### DIFF
--- a/docs/S10-eth2/M1-background/index.md
+++ b/docs/S10-eth2/M1-background/index.md
@@ -49,3 +49,4 @@ You can read the entire Ethereum 2.0 spec, including phases 0, 1 and 2 [here.](h
 - <a href="https://consensys.net/blog/blockchain-explained/my-journey-to-becoming-a-validator-on-ethereum-2-0/" target="_blank" rel="noopener noreferrer">My Journey to Becoming a Validator on Ethereum 2.0 — Part 1</a> Coogan walks through a four-part series of becoming a validator on Ethereum 2.0. Started before the Beacon Chain launched!
 - To follow the progress of Ethereum 2.0, subscribe to [What's New in Eth2,](https://hackmd.io/@benjaminion/eth2_news/https%3A%2F%2Fhackmd.io%2F%40benjaminion%2Fwnie2_200822){target=_blank} which sends weekly updates.
 - [A Merge Timeline from AllCoreDevs (Tim Beiko)](https://tim.mirror.xyz/sR23jU02we6zXRgsF_oTUkttL83S3vyn05vJWnnp-Lc){target=_blank} 
+- [Ethereum’s Merge Upgrade Goes Live Today on Ropsten Testnet](https://decrypt.co/102320/ethereum-merge-ropsten-live)


### PR DESCRIPTION
Adding an article by Decrypt Media about the Ropsten Merge that occurred on Wednesday, June 8th, 2022.