### PR TITLE
add code owners to ping people to review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-docs/* @guibibeau @cooganb @dinadeljanin @emilyJLin95 @Gtonizuka @httpJunkie @kevinbluer @ziad-saab
+docs/* @guibibeau @cooganb @dinadeljanin @emilyJLin95 @Gtonizuka @httpJunkie @ziad-saab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+docs/* @guibibeau @cooganb @dinadeljanin @emilyJLin95 @Gtonizuka @httpJunkie @kevinbluer @ziad-saab


### PR DESCRIPTION
only docs are covered for now to avoid pinging people on the actual implementation of the platform
